### PR TITLE
Small update in .gitignore file to stop tracking unwanted items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,3 +220,7 @@ fabric.properties
 # Editor-based Rest Client
 .idea/httpRequests
 .idea
+
+# composer
+/vendor
+composer.lock


### PR DESCRIPTION
The **vendor/** directory and **composer.lock** should never been tracked by git, adding both items to **.gitignore** might avoid possible issues as committing by error **vendor/** items and/or **.lock** file.