### PR TITLE
Handle POST Fail messages that have special characters

### DIFF
--- a/src/FulfillmentAutomation.php
+++ b/src/FulfillmentAutomation.php
@@ -84,7 +84,7 @@ abstract class FulfillmentAutomation extends AutomationEngine implements Fulfill
             $this->tierConfiguration->sendRequest(
                 'POST',
                 '/tier/config-requests/' . $tierConfigRequest->id . '/fail',
-                '{"reason": "' . $e->getMessage() . '"}'
+                json_encode( ['reason' => $e->getMessage()] )
             );
             $processingResult = 'fail';
         } catch (Skip $e) {
@@ -156,7 +156,7 @@ abstract class FulfillmentAutomation extends AutomationEngine implements Fulfill
             $this->fulfillment->sendRequest(
                 'POST',
                 '/requests/' . $request->id . '/fail',
-                '{"reason": "' . $e->getMessage() . '"}'
+                json_encode( ['reason' => $e->getMessage()] )
             );
             try {
                 $request->conversation()->addMessage($e->getMessage());


### PR DESCRIPTION
Hit this issue whilst throwing an exception with double quotes. Using json_encode is a safe way to send back any string that Exception's `getMessage()` might return in this context.